### PR TITLE
Now logging out after LIDAR reconfiguration

### DIFF
--- a/LMS1xx/src/LMS1xx_node.cpp
+++ b/LMS1xx/src/LMS1xx_node.cpp
@@ -92,6 +92,8 @@ int main(int argc, char **argv)
     }
     while (stat != ready_for_measurement);
 
+    laser.startDevice(); // Log out to properly re-enable system after config
+
     laser.scanContinous(1);
 
     while (ros::ok())


### PR DESCRIPTION
Preserves more sensor functionality. Without it, the digital outputs were
not working.

As per workflow on page #7 of the official manual (SICK manual #8014631).
