### PR TITLE
fix ld error

### DIFF
--- a/lms1xx/CMakeLists.txt
+++ b/lms1xx/CMakeLists.txt
@@ -108,8 +108,8 @@ add_executable(set_config src/setConfig.cpp)
 # add_dependencies(LMS1xx_node LMS1xx_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(LMS1xx_node lms1xx ${catkin_LIBRARIES})
-target_link_libraries(set_config lms1xx ${catkin_LIBRARIES})
+target_link_libraries(LMS1xx_node ${catkin_LIBRARIES})
+target_link_libraries(set_config ${catkin_LIBRARIES})
 
 #target_link_libraries ( test_libLMS1xx LMS1xx )
 


### PR DESCRIPTION
This fixes the following error:

```
Linking CXX executable
```

/home/martin/ros-hydro-ws/devel/lib/lms1xx/set_config
   Linking CXX executable
/home/martin/ros-hydro-ws/devel/lib/lms1xx/LMS1xx_node
   /usr/bin/ld: cannot find -llms1xx
   collect2: ld returned 1 exit status
   make[2]: **\* [/home/martin/ros-hydro-ws/devel/lib/lms1xx/set_config] Error
1
   make[1]: **\* [CMakeFiles/set_config.dir/all] Error 2
   make[1]: **\* Waiting for unfinished jobs....
   /usr/bin/ld: cannot find -llms1xx
   collect2: ld returned 1 exit status
   make[2]: **\* [/home/martin/ros-hydro-ws/devel/lib/lms1xx/LMS1xx_node] Error
1
   make[1]: **\* [CMakeFiles/LMS1xx_node.dir/all] Error 2
   make: **\* [all] Error 2

The error happens sometimes with `catkin_make` (especially after first 
removing the build directory), but can be reliably reproduced with the new
[catkin tool](http://catkin-tools.readthedocs.org).
